### PR TITLE
refactor metadata API.

### DIFF
--- a/src/cas.rs
+++ b/src/cas.rs
@@ -1,11 +1,10 @@
-pub mod block;
 pub mod block_stream;
-pub mod bucket_meta;
+pub mod multipart;
+pub mod range_request;
+pub use fs::CasFS;
+mod block;
+mod bucket_meta;
 mod buffered_byte_stream;
 mod errors;
 mod fs;
-pub mod multipart;
-pub mod object;
-pub mod range_request;
-
-pub use fs::CasFS;
+mod object;

--- a/src/cas/object.rs
+++ b/src/cas/object.rs
@@ -34,6 +34,10 @@ impl Object {
         }
     }
 
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
     pub fn format_e_tag(&self) -> String {
         if self.parts == 0 {
             format!("\"{}\"", hex_string(&self.e_tag))

--- a/src/s3fs.rs
+++ b/src/s3fs.rs
@@ -406,7 +406,7 @@ impl S3 for S3FS {
         &self,
         _: S3Request<ListBucketsInput>,
     ) -> S3Result<S3Response<ListBucketsOutput>> {
-        let csfs_buckets = try_!(self.casfs.buckets());
+        let csfs_buckets = try_!(self.casfs.get_buckets());
         let mut buckets = Vec::with_capacity(csfs_buckets.len());
         for bucket in csfs_buckets {
             let bucket = Bucket {


### PR DESCRIPTION
- don't expose `sled::Tree` and `sled::Error`
- simplify the API

Part of #16 