### PR TITLE
remove s3_server::dto::ByteStream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "openssl",
  "pin-project-lite 0.2.16",
  "prometheus",
+ "rusoto_core",
  "s3-server",
  "s3s",
  "s3s-aws",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ hyper-util = { version = "0.1.9", features = [
     "http2",
     "tokio",
 ] }
+rusoto_core = "0.47.0"
 
 [profile.release]
 lto = true

--- a/src/cas/buffered_byte_stream.rs
+++ b/src/cas/buffered_byte_stream.rs
@@ -1,6 +1,6 @@
 use super::fs::BLOCK_SIZE;
 use futures::{ready, Stream};
-use s3_server::dto::ByteStream;
+use rusoto_core::ByteStream;
 use std::{
     io, mem,
     pin::Pin,

--- a/src/cas/fs.rs
+++ b/src/cas/fs.rs
@@ -17,7 +17,7 @@ use futures::{
     stream::{StreamExt, TryStreamExt},
 };
 use md5::{Digest, Md5};
-use s3_server::dto::ByteStream;
+use rusoto_core::ByteStream;
 use sled::{Db, Transactional};
 use std::{
     convert::{TryFrom, TryInto},

--- a/src/s3fs.rs
+++ b/src/s3fs.rs
@@ -10,7 +10,7 @@ use tracing::error;
 use tracing::info;
 use uuid::Uuid;
 
-use s3_server::dto::ByteStream;
+use rusoto_core::ByteStream;
 use s3s::dto::StreamingBlob;
 use s3s::dto::Timestamp;
 use s3s::dto::{


### PR DESCRIPTION
Use it directly from rusoto_core.

`s3_server::dto::ByteStream` only aliasing from the `rusoto_core`

Part of #30