### PR TITLE
metadata: return None when object not exists.

### DIFF
--- a/src/cas/multipart.rs
+++ b/src/cas/multipart.rs
@@ -186,9 +186,13 @@ impl MultiPartTree {
         self.tree.remove(key)
     }
 
-    pub fn get_multipart_part(&self, key: &[u8]) -> Result<MultiPart, MetaError> {
-        let value = self.tree.get(key)?;
+    pub fn get_multipart_part(&self, key: &[u8]) -> Result<Option<MultiPart>, MetaError> {
+        let value = match self.tree.get(key) {
+            Ok(Some(v)) => v,
+            Ok(None) => return Ok(None),
+            Err(e) => return Err(e),
+        };
         let mp = MultiPart::try_from(value.as_ref()).expect("Corrupted multipart data");
-        Ok(mp)
+        Ok(Some(mp))
     }
 }

--- a/src/metastore/traits.rs
+++ b/src/metastore/traits.rs
@@ -96,7 +96,7 @@ pub trait BaseMetaTree: Send + Sync {
 
     fn contains_key(&self, key: &[u8]) -> Result<bool, MetaError>;
 
-    fn get(&self, key: &[u8]) -> Result<Vec<u8>, MetaError>;
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MetaError>;
 }
 
 pub trait AllBucketsTree: BaseMetaTree {}
@@ -109,12 +109,12 @@ pub trait BucketTree: BaseMetaTree {
 
     /// get_meta returns the Object metadata for the given bucket and key.
     /// We return the Object struct instead of the raw bytes for performance reason.
-    fn get_meta(&self, key: &str) -> Result<Object, MetaError>;
+    fn get_meta(&self, key: &str) -> Result<Option<Object>, MetaError>;
 }
 
 pub trait BlockTree: Send + Sync {
     /// get_block_obj returns the `Object` for the given key.
-    fn get_block(&self, key: &[u8]) -> Result<Block, MetaError>;
+    fn get_block(&self, key: &[u8]) -> Result<Option<Block>, MetaError>;
 }
 
 pub trait BucketTreeExt: BaseMetaTree {


### PR DESCRIPTION
It previously returns error, which sometimes being treated as internal error.